### PR TITLE
Fix: Amélioration du contraste des champs de sélection

### DIFF
--- a/src/components/Select/SelectField.tsx
+++ b/src/components/Select/SelectField.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface SelectFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+}
+
+export const SelectField: React.FC<SelectFieldProps> = ({ value, onChange, options, placeholder }) => {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="
+        block w-full px-3 py-2 text-sm
+        border rounded-md shadow-sm
+        bg-white dark:bg-gray-800
+        text-gray-900 dark:text-gray-100
+        border-gray-300 dark:border-gray-600
+        focus:ring-2 focus:ring-blue-500 focus:border-blue-500
+        dark:focus:ring-blue-400 dark:focus:border-blue-400
+        cursor-pointer
+        transition-colors
+      "
+    >
+      {placeholder && (
+        <option value="" disabled>
+          {placeholder}
+        </option>
+      )}
+      {options.map((option) => (
+        <option
+          key={option.value}
+          value={option.value}
+          className="
+            bg-white dark:bg-gray-800
+            text-gray-900 dark:text-gray-100
+          "
+        >
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/src/components/TransactionTable/Table.tsx
+++ b/src/components/TransactionTable/Table.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { SelectField } from '../Select/SelectField';
+
+export const Table = ({ transactions, onUpdateTransaction }) => {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead className="bg-gray-50 dark:bg-opacity-5">
+          <tr>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Date</th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Description</th>
+            <th scope="col" className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Montant</th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Catégorie</th>
+            <th scope="col" className="relative px-6 py-3">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200 dark:bg-transparent dark:divide-gray-700">
+          {transactions.map((transaction, index) => (
+            <tr key={index} className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-300">{transaction.date}</td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-300">{transaction.description}</td>
+              <td className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${transaction.amount < 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
+                {transaction.amount.toFixed(2)} €
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm">
+                <SelectField
+                  value={transaction.type}
+                  onChange={(value) => onUpdateTransaction(transaction.id, { type: value })}
+                  options={[
+                    { value: 'virement', label: 'Virement' },
+                    { value: 'cheque', label: 'Chèque' },
+                    { value: 'prelevement', label: 'Prélèvement' },
+                    { value: 'paiement_carte', label: 'Paiement carte' }
+                  ]}
+                />
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-sm">
+                <SelectField
+                  value={transaction.category}
+                  onChange={(value) => onUpdateTransaction(transaction.id, { category: value })}
+                  options={[
+                    { value: 'epargne', label: 'Épargne' },
+                    { value: 'frais_bancaires', label: 'Frais bancaires' },
+                    { value: 'revenus', label: 'Revenus' }
+                  ]}
+                />
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <button className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300">
+                  Modifier
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};


### PR DESCRIPTION
Cette PR corrige le problème de contraste dans les champs de sélection lorsqu'on passe du mode sombre au mode clair.

### Changements apportés

1. **Nouveau composant SelectField**
- Création d'un composant réutilisable pour les champs de sélection
- Gestion adaptative des couleurs selon le thème
- Meilleure accessibilité avec les états focus et hover

2. **Corrections de style**
- Ajustement des couleurs pour assurer une bonne lisibilité en mode clair
- Adaptation des couleurs de fond et de texte selon le thème
- Correction des contrastes pour les options des menus déroulants

3. **Améliorations techniques**
- Utilisation de classes Tailwind pour une meilleure maintenabilité
- Transition fluide entre les modes clair et sombre
- Support TypeScript amélioré

### Comment tester
1. Basculer entre le mode sombre et le mode clair
2. Vérifier que le texte est lisible dans les deux modes
3. Tester l'interactivité des champs de sélection
4. Vérifier le contraste des options dans les menus déroulants

### Screenshots
(Des captures d'écran peuvent être ajoutées pour montrer le avant/après)