### PR TITLE
feat: Add dark mode support with system preference

### DIFF
--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/sidebar"
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
+import { ThemeToggle } from "@/components/theme/ThemeToggle"
 
 const menuItems = [
   {
@@ -57,7 +58,7 @@ export function AppSidebar() {
       onMouseLeave={() => handleMouseEvents(false)}
     >
       {/* Thin visible strip to trigger sidebar */}
-      <div className="absolute left-0 top-0 w-2 h-full bg-gray-200 hover:bg-accent/10 transition-colors" />
+      <div className="absolute left-0 top-0 w-2 h-full bg-gray-200 hover:bg-accent/10 transition-colors dark:bg-gray-800" />
       
       <Sidebar>
         <SidebarContent>
@@ -97,6 +98,13 @@ export function AppSidebar() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
+          {/* Theme Toggle */}
+          <div className="mt-auto p-4 border-t dark:border-gray-800">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">Theme</span>
+              <ThemeToggle />
+            </div>
+          </div>
         </SidebarContent>
       </Sidebar>
     </div>

--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -1,12 +1,13 @@
+import React from 'react';
 import { Moon, Sun, Laptop } from "lucide-react";
-import { Button } from "../ui/button";
+import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
-import { useTheme } from "../../hooks/use-theme";
+} from "@/components/ui/dropdown-menu"
+import { useTheme } from "@/hooks/use-theme"
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
@@ -14,7 +15,7 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="w-8 h-8 relative">
+        <Button variant="outline" size="icon" className="w-8 h-8 relative">
           <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>

--- a/src/components/theme/ThemeToggle.tsx
+++ b/src/components/theme/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+import { Moon, Sun, Laptop } from "lucide-react";
+import { Button } from "../ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { useTheme } from "../../hooks/use-theme";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="w-8 h-8 relative">
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="mr-2 h-4 w-4" />
+          <span>Light</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="mr-2 h-4 w-4" />
+          <span>Dark</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Laptop className="mr-2 h-4 w-4" />
+          <span>System</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/hooks/use-theme.tsx
+++ b/src/hooks/use-theme.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
 
-type Theme = "dark" | "light";
+type Theme = "dark" | "light" | "system";
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -14,7 +14,7 @@ type ThemeProviderState = {
 };
 
 const initialState: ThemeProviderState = {
-  theme: "light",
+  theme: "system",
   setTheme: () => null,
 };
 
@@ -22,8 +22,8 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
 export function ThemeProvider({
   children,
-  defaultTheme = "light",
-  storageKey = "vite-ui-theme",
+  defaultTheme = "system",
+  storageKey = "finance-theme",
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
@@ -33,7 +33,29 @@ export function ThemeProvider({
   useEffect(() => {
     const root = window.document.documentElement;
     root.classList.remove("light", "dark");
-    root.classList.add(theme);
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+      root.classList.add(systemTheme);
+    } else {
+      root.classList.add(theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => {
+      if (theme === "system") {
+        const root = window.document.documentElement;
+        root.classList.remove("light", "dark");
+        root.classList.add(mediaQuery.matches ? "dark" : "light");
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
   }, [theme]);
 
   const value = {


### PR DESCRIPTION
This PR adds support for dark mode with the following features:

## Changes
- Added theme toggle component with support for light, dark and system themes
- Integrated theme toggle in the sidebar
- Added support for system theme preference
- Improved dark mode styling for sidebar elements

## Technical Changes
1. Created new `ThemeToggle` component:
   - Uses shadcn/ui components for consistent styling
   - Supports three modes: light, dark, system
   - Animates smoothly between states

2. Modified AppSidebar:
   - Added theme toggle section at the bottom
   - Added dark mode specific styling
   - Improved visual separation with border

## Testing
- [ ] Test theme persistence after page reload
- [ ] Test system theme preference sync
- [ ] Test theme toggle functionality
- [ ] Verify dark mode styling in all components